### PR TITLE
Make it possible to extract `text/xml` requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Content type of request | Type of request body
 `application/x-www-form-urlencoded` | `Map<String, String>`
 `multipart/form-data` | `Map<String, Part>`
 `application/json` and subset | `Map<String, Object>`
-`application/xml` and subset | `Map<String, Object>`
+`application/xml` and subset, `text/xml` and subset | `Map<String, Object>`
 `text/*` | `String`
 Otherwise | `null`
 

--- a/src/main/java/org/hidetake/stubyaml/app/RequestExtractor.java
+++ b/src/main/java/org/hidetake/stubyaml/app/RequestExtractor.java
@@ -59,7 +59,7 @@ public class RequestExtractor {
                             throw new RuntimeException(e);
                         }
                     });
-            } else if (APPLICATION_XML.includes(contentType)) {
+            } else if (APPLICATION_XML.includes(contentType) || TEXT_XML.includes(contentType)) {
                 // Convert to String in order to receive non UTF-8 charset
                 return extractBodyAsString(request)
                     .doOnSuccess(string -> requestResponseLogger.logRequest(request, string))


### PR DESCRIPTION
`application/xml`と同様にリクエストのMIME Typeが`text/xml`の場合でも、リクエストの内容をレスポンスの定義に使用できるように変更を加えました。