### PR TITLE
WIP : headerで同一のキーで複数のvalueを返却できるようにする

### DIFF
--- a/data/features/request-body-type.post.yaml
+++ b/data/features/request-body-type.post.yaml
@@ -1,6 +1,7 @@
 - response:
     headers:
-      content-type: text/plain
+      content-type:
+        - text/plain
     body: |-
       ${switch (body) {
         case null: return 'null'

--- a/data/features/request-body-value.post.yaml
+++ b/data/features/request-body-value.post.yaml
@@ -1,4 +1,5 @@
 - response:
     headers:
-      content-type: "text/plain;charset=${params.charset ?: 'UTF-8'}"
+      content-type:
+        - "text/plain;charset=${params.charset ?: 'UTF-8'}"
     body: ${body}

--- a/data/features/response-json-charset.get.yaml
+++ b/data/features/response-json-charset.get.yaml
@@ -1,6 +1,7 @@
 - response:
     headers:
-      content-type: "application/json;charset=${params.charset ?: 'UTF-8'}"
+      content-type:
+        - "application/json;charset=${params.charset ?: 'UTF-8'}"
     body:
       - id: 1
         name: あいうえお

--- a/data/groups/1.get.yaml
+++ b/data/groups/1.get.yaml
@@ -1,6 +1,7 @@
 - response:
     headers:
-      content-type: application/json
+      content-type:
+        - application/json
     body: |
       {
         "id": 1,

--- a/data/numbers.get.yaml
+++ b/data/numbers.get.yaml
@@ -1,18 +1,21 @@
 - when: params.order == 'desc'
   response:
     headers:
-      content-type: application/json
+      content-type:
+        - application/json
     body: [3, 2, 1]
 
 - when: params.order == 'asc'
   response:
     headers:
-      content-type: application/json
+      content-type:
+       - application/json
     body: [1, 2, 3]
 
 - response:
     status: 400
     headers:
-      content-type: application/json
+      content-type:
+       - application/json
     body:
       error: require_parameter

--- a/data/users.get.yaml
+++ b/data/users.get.yaml
@@ -1,7 +1,12 @@
 - response:
     headers:
-      content-type: application/json
-      x-uuid: ${UUID.randomUUID()}
+      content-type:
+        - application/json
+      x-uuid:
+        - ${UUID.randomUUID()}
+      set-cookie:
+        - hoge=A
+        - fuga=B
     body:
       - id: 1
         name: Foo

--- a/data/users.post.yaml
+++ b/data/users.post.yaml
@@ -1,7 +1,8 @@
 - response:
     delay: 500
     headers:
-      content-type: application/json
+      content-type:
+        - application/json
     body:
       id: ${body.id}
       name: ${body.name}

--- a/data/users/{userId}.get.yaml
+++ b/data/users/{userId}.get.yaml
@@ -1,6 +1,7 @@
 - response:
     headers:
-      content-type: application/json
+      content-type:
+        - application/json
     body:
       id: ${path.userId}
       name: ${table.userName}

--- a/data/users/{userId}/photo.post.yaml
+++ b/data/users/{userId}/photo.post.yaml
@@ -1,7 +1,8 @@
 - response:
     delay: 500
     headers:
-      content-type: application/json
+      content-type:
+        - application/json
     body:
       id: ${UUID.randomUUID()}
       filename: ${body.file.filename()}

--- a/src/main/java/org/hidetake/stubyaml/app/ResponseRenderer.java
+++ b/src/main/java/org/hidetake/stubyaml/app/ResponseRenderer.java
@@ -39,7 +39,8 @@ public class ResponseRenderer {
 
     private Mono<ServerResponse> renderInternal(CompiledResponse compiledResponse, ResponseContext responseContext) {
         final var headers = new HttpHeaders();
-        headers.setAll(compiledResponse.evaluateHeaders(responseContext));
+        compiledResponse.evaluateHeaders(responseContext)
+            .forEach((headerName, headerValues) -> headerValues.forEach(header -> headers.add(headerName, header)));
 
         final var responseBuilder = ServerResponse
             .status(compiledResponse.getHttpStatus())

--- a/src/main/java/org/hidetake/stubyaml/model/ResponseCompiler.java
+++ b/src/main/java/org/hidetake/stubyaml/model/ResponseCompiler.java
@@ -27,7 +27,8 @@ public class ResponseCompiler {
 
         return CompiledResponse.builder()
             .status(response.getStatus())
-            .headers(mapValue(response.getHeaders(), value -> expressionCompiler.compileTemplate(value, source)))
+            .headers(mapValue(response.getHeaders(),
+                value -> value.stream().map(v -> expressionCompiler.compileTemplate(v, source)).collect(toList())))
             .body(compileBody(response, source))
             .tables(tableCompiler.compile(response.getTables(), source))
             .delay(computeDelay(response, source))

--- a/src/main/java/org/hidetake/stubyaml/model/execution/CompiledResponse.java
+++ b/src/main/java/org/hidetake/stubyaml/model/execution/CompiledResponse.java
@@ -6,7 +6,9 @@ import org.hidetake.stubyaml.util.MapUtils;
 import org.springframework.http.HttpStatus;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.springframework.util.ObjectUtils.nullSafeToString;
 
@@ -14,7 +16,7 @@ import static org.springframework.util.ObjectUtils.nullSafeToString;
 @Builder
 public class CompiledResponse {
     private final int status;
-    private final Map<String, CompiledExpression> headers;
+    private final Map<String, List<CompiledExpression>> headers;
     private final CompiledResponseBody body;
     private final CompiledTables tables;
     private final Duration delay;
@@ -23,8 +25,9 @@ public class CompiledResponse {
         return HttpStatus.valueOf(status);
     }
 
-    public Map<String, String> evaluateHeaders(ResponseContext responseContext) {
+    public Map<String, List<String>> evaluateHeaders(ResponseContext responseContext) {
         return MapUtils.mapValue(headers, expression ->
-            nullSafeToString(expression.evaluate(responseContext)));
+            expression.stream().map(
+                v -> nullSafeToString(v.evaluate(responseContext))).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/hidetake/stubyaml/model/yaml/Response.java
+++ b/src/main/java/org/hidetake/stubyaml/model/yaml/Response.java
@@ -9,7 +9,7 @@ import java.util.Map;
 @Data
 public class Response {
     private int status = 200;
-    private Map<String, String> headers = Collections.emptyMap();
+    private Map<String, List<String>> headers = Collections.emptyMap();
 
     /**
      * Response body.


### PR DESCRIPTION
複数ヘッダーを返却するようにできました。

headersの定義の型が`Map<String, String>`から`Map<String, List<String>>`になっているのでテストデータも一式変わっています。