### PR TITLE
Add multiple header values feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,37 @@ Following methods are supported.
 - TRACE
 
 
-### Content type
+### Path variables
 
-Set the content type header as follows:
+A braced string in the file path is treated as a path variable.
+For example, create `/users/{userId}.get.yaml` for handling `/users/1`, `/users/2` and so on.
+
+
+### Response header
+
+You can set pairs of key and value to the headers. The value must be a string and is parsed as a template (see also the later section).
+
+```yaml
+- response:
+    headers:
+      content-type: text/plain
+      x-uuid: "1234567890"
+```
+
+You can set multiple values.
+
+```yaml
+- response:
+    headers:
+      set-cookie:
+        - sessionId=38afes7a8
+        - id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT
+```
+
+
+### Response body
+
+You can serve a text body as follows:
 
 ```yaml
 - response:
@@ -141,53 +169,33 @@ Set the content type header as follows:
       </users>
 ```
 
-Set the character set for response body if needed:
-
-```yaml
-- response:
-    headers:
-      content-type: text/plain;charset=Shift_JIS
-    body: Example
-```
-
-
-### Response file
-
-You can specify a `file` instead of `body` as follows:
-
-```yaml
-- response:
-    headers:
-      content-type: image/jpeg
-    file: photo.jpg
-```
-
-
-### Path variables
-
-A braced string in the file path is treated as a path variable.
-For example, create `/users/{userId}.get.yaml` for handling `/users/1`, `/users/2` and so on.
-
-
-### Constants
-
-Define constants in `data/config.yaml`:
-
-```yaml
-constants:
-  today: "2017-12-01"
-```
-
-You can use constants in a route YAML:
+You can serve a JSON body as follows:
 
 ```yaml
 - response:
     headers:
       content-type: application/json
     body:
-      - id: 1
-        name: Foo
-        registeredDate: ${constants.today}
+      id: 1
+      name: Alice
+```
+
+If a character set is specified in the `content-type` header, the response body is encoded to the character set.
+
+```yaml
+- response:
+    headers:
+      content-type: text/plain;charset=Shift_JIS
+    body: あいうえお
+```
+
+You can serve a file content as follows:
+
+```yaml
+- response:
+    headers:
+      content-type: image/jpeg
+    file: photo.jpg
 ```
 
 
@@ -227,7 +235,7 @@ For example, create `/users/{userId}.get.yaml` as following:
     headers:
       content-type: application/json
     body:
-      id: ${path.userId},
+      id: ${path.userId}
       name: User${path.userId}
 ```
 
@@ -275,6 +283,28 @@ And on the request `GET /numbers?order=desc`:
 ```
 
 If the last resort is not defined, the stub will return 404.
+
+
+### Constants
+
+Define constants in `data/config.yaml`:
+
+```yaml
+constants:
+  today: "2017-12-01"
+```
+
+You can use constants in a route YAML:
+
+```yaml
+- response:
+    headers:
+      content-type: application/json
+    body:
+      - id: 1
+        name: Foo
+        registeredDate: ${constants.today}
+```
 
 
 ### Tables

--- a/data/users.get.yaml
+++ b/data/users.get.yaml
@@ -2,6 +2,9 @@
     headers:
       content-type: application/json
       x-uuid: ${UUID.randomUUID()}
+      x-uid:
+        - "10000"
+        - "20000"
     body:
       - id: 1
         name: Foo

--- a/src/main/java/org/hidetake/stubyaml/app/ResponseRenderer.java
+++ b/src/main/java/org/hidetake/stubyaml/app/ResponseRenderer.java
@@ -39,7 +39,7 @@ public class ResponseRenderer {
 
     private Mono<ServerResponse> renderInternal(CompiledResponse compiledResponse, ResponseContext responseContext) {
         final var headers = new HttpHeaders();
-        headers.setAll(compiledResponse.evaluateHeaders(responseContext));
+        headers.addAll(compiledResponse.evaluateHeaders(responseContext));
 
         final var responseBuilder = ServerResponse
             .status(compiledResponse.getHttpStatus())

--- a/src/main/java/org/hidetake/stubyaml/model/execution/CompiledResponse.java
+++ b/src/main/java/org/hidetake/stubyaml/model/execution/CompiledResponse.java
@@ -2,19 +2,19 @@ package org.hidetake.stubyaml.model.execution;
 
 import lombok.Builder;
 import lombok.Data;
-import org.hidetake.stubyaml.util.MapUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.MultiValueMap;
 
 import java.time.Duration;
-import java.util.Map;
 
+import static org.hidetake.stubyaml.util.MapUtils.mapMultiValue;
 import static org.springframework.util.ObjectUtils.nullSafeToString;
 
 @Data
 @Builder
 public class CompiledResponse {
     private final int status;
-    private final Map<String, CompiledExpression> headers;
+    private final MultiValueMap<String, CompiledExpression> headers;
     private final CompiledResponseBody<?> body;
     private final CompiledTables tables;
     private final Duration delay;
@@ -23,8 +23,8 @@ public class CompiledResponse {
         return HttpStatus.valueOf(status);
     }
 
-    public Map<String, String> evaluateHeaders(ResponseContext responseContext) {
-        return MapUtils.mapValue(headers, expression ->
+    public MultiValueMap<String, String> evaluateHeaders(ResponseContext responseContext) {
+        return mapMultiValue(headers, expression ->
             nullSafeToString(expression.evaluate(responseContext)));
     }
 }

--- a/src/main/java/org/hidetake/stubyaml/model/yaml/Response.java
+++ b/src/main/java/org/hidetake/stubyaml/model/yaml/Response.java
@@ -9,7 +9,12 @@ import java.util.Map;
 @Data
 public class Response {
     private int status = 200;
-    private Map<String, String> headers = Collections.emptyMap();
+
+    /**
+     * Response header.
+     * The value must be one of {@link String} or {@link List}.
+     */
+    private Map<String, Object> headers = Collections.emptyMap();
 
     /**
      * Response body.

--- a/src/main/java/org/hidetake/stubyaml/util/MapUtils.java
+++ b/src/main/java/org/hidetake/stubyaml/util/MapUtils.java
@@ -1,13 +1,23 @@
 package org.hidetake.stubyaml.util;
 
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class MapUtils {
     public static <K, V1, V2> Map<K, V2> mapValue(Map<K, V1> source, Function<V1, V2> transform) {
         final var target = new HashMap<K, V2>(source.size());
         source.forEach((key, value) -> target.put(key, transform.apply(value)));
+        return target;
+    }
+
+    public static <K, V1, V2> MultiValueMap<K, V2> mapMultiValue(MultiValueMap<K, V1> source, Function<V1, V2> transform) {
+        final var target = new LinkedMultiValueMap<K, V2>(source.size());
+        source.forEach((key, value) -> target.put(key, value.stream().map(transform).collect(Collectors.toList())));
         return target;
     }
 }

--- a/src/test/groovy/org/hidetake/stubyaml/test/integration/StubSpec.groovy
+++ b/src/test/groovy/org/hidetake/stubyaml/test/integration/StubSpec.groovy
@@ -24,6 +24,7 @@ class StubSpec extends Specification {
         users.body[0] == new User(1, 'Foo')
         users.body[1] == new User(2, 'Bar')
         !users.headers.getFirst('x-uuid').empty
+        users.headers.get('x-uid') == ['10000', '20000']
     }
 
     @Unroll


### PR DESCRIPTION
This will add the feature so that a header value accept both a string and list. It allows multiple header values, for example,

```
x-uid: abcde
x-uid: asdfg
```

TODOs:

- [x] Change the e2e test.
- [x] Change the doc.