### PR TITLE
Update docker base image from openjdk:8-jdk-alpine to openjdk:11-jdk-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Build App
-FROM openjdk:8-jdk-alpine AS BUILD
+FROM openjdk:11-jdk-slim AS BUILD
 
 ADD . /work
 WORKDIR /work
 RUN ./gradlew build --build-file ./build.gradle
 
 # Run App
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre-slim
 
 COPY --from=BUILD /work/build/libs/httpstub.jar /app/httpstub.jar
 EXPOSE 8080
 WORKDIR /app
-ENTRYPOINT /usr/bin/java -jar httpstub.jar
+ENTRYPOINT java -jar httpstub.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # Build App
 FROM openjdk:11-jdk-slim AS BUILD
 
-ADD . /work
+COPY *.gradle gradle.* gradlew /work/
+COPY gradle /work/gradle
 WORKDIR /work
+RUN ./gradlew --version
+
+COPY . /work
 RUN ./gradlew build --build-file ./build.gradle
 
 # Run App
@@ -11,4 +15,4 @@ FROM openjdk:11-jre-slim
 COPY --from=BUILD /work/build/libs/httpstub.jar /app/httpstub.jar
 EXPOSE 8080
 WORKDIR /app
-ENTRYPOINT java -jar httpstub.jar
+ENTRYPOINT ["java", "-jar", "httpstub.jar"]


### PR DESCRIPTION
Update docker base image from openjdk-8 to openjdk-11.

There is no openjdk11 alpine image, only support 8 and 13 so it would be debian slim image. ( https://github.com/docker-library/openjdk/issues/211 )